### PR TITLE
Lower cert renewal to 4 hours

### DIFF
--- a/src/dnscrypt_certs.rs
+++ b/src/dnscrypt_certs.rs
@@ -13,7 +13,7 @@ use std::slice;
 use std::sync::Arc;
 
 pub const DNSCRYPT_CERTS_TTL: u32 = 86400;
-pub const DNSCRYPT_CERTS_RENEWAL: u32 = 28800;
+pub const DNSCRYPT_CERTS_RENEWAL: u32 = 14400;
 
 fn now() -> u32 {
     Clock::recent_since_epoch().as_secs() as u32


### PR DESCRIPTION
The default https://github.com/DNSCrypt/dnscrypt-proxy/blob/master/dnscrypt-proxy/example-dnscrypt-proxy.toml does:
cert_refresh_delay = 240
to refresh the cert every 4 hours, but encrypted-dns-server defaults to every 8 hours.
So anyone using the default example-dnscrypt-proxy.toml settings to connect to an encrypted-dns-server instance will start getting those "No useable certificate found" errors after 4 hours.
Probably should lower the refresh here to 4 hours, unless I missed a config directive for encrypted-dns-server that'll do it.
If there's not a config directive, could create one that allows changing DNSCRYPT_CERTS_RENEWAL using the config, and have it default there to 4 hours.