### PR TITLE
Second upstream_private for vpn clients and split-dns

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,7 @@ pub struct Config {
     pub listen_addrs: Vec<ListenAddrConfig>,
     pub external_addr: Option<IpAddr>,
     pub upstream_addr: SocketAddr,
+    pub upstream_addr_private: SocketAddr,
     pub state_file: PathBuf,
     pub udp_timeout: u32,
     pub tcp_timeout: u32,

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -27,6 +27,7 @@ pub struct Globals {
     pub listen_addrs: Vec<SocketAddr>,
     pub external_addr: Option<SocketAddr>,
     pub upstream_addr: SocketAddr,
+    pub upstream_addr_private: SocketAddr,
     pub tls_upstream_addr: Option<SocketAddr>,
     pub udp_timeout: Duration,
     pub tcp_timeout: Duration,

--- a/src/main.rs
+++ b/src/main.rs
@@ -709,6 +709,7 @@ fn main() -> Result<(), Error> {
         provider_kp,
         listen_addrs,
         upstream_addr: config.upstream_addr,
+        upstream_addr_private: config.upstream_addr_private,
         tls_upstream_addr: config.tls.upstream_addr,
         external_addr,
         tcp_timeout: Duration::from_secs(u64::from(config.tcp_timeout)),


### PR DESCRIPTION
Hi Frank, this would be useful for clients with vpn where upstream has split-dns, when client comes with public IP it goes to main upstream, and when vpn is on and client comes with reserved IP it would use different upstream. Open to discuss it or to try to make it cleaner (I'm learning Rust), if you think it's ok.